### PR TITLE
fix: address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,13 +93,13 @@
 
 ### Major New Features
 
-#### **Container-Based Tool Execution with Dagger** 
+#### **Container-Based Tool Execution with Dagger**
 - **Twitter Scraper**: Scrape tweets from any Twitter account using Apify API
   - Configurable tweet count
   - Structured JSON output with tweet metadata, engagement stats
   - Secure API key management through environment variables
 - **Telegram Bot Integration**: Post messages to Telegram channels programmatically
-  - Support for custom channels or default channel configuration  
+  - Support for custom channels or default channel configuration
   - Real-time message delivery with confirmation responses
   - Perfect for notifications, alerts, and automated reporting
 - **Python Analytics Engine**: Execute custom Python scripts in isolated containers
@@ -151,7 +151,7 @@
 
 - **Configuration Parsing**: Fixed YAML configuration loading issues
 - **A2A Card Handler**: Resolved agent card exchange and local function registration
-- **P2P Discovery**: Fixed peer discovery mechanism reliability  
+- **P2P Discovery**: Fixed peer discovery mechanism reliability
 - **API Security**: Removed unsafe API server calls and improved authentication
 - **Processing Time**: Fixed incorrect type handling for processing time metrics
 
@@ -176,7 +176,7 @@
 - **MCP Library Migration**: Updated from custom MCP implementation to `mark3labs/mcp-go`
   - Existing MCP configurations may need minor adjustments
   - See migration guide in documentation
-  
+
 ### Upgrade Guide
 
 1. **Update Configuration**: Review your `configs/agent.yaml` for new options

--- a/README.md
+++ b/README.md
@@ -174,4 +174,3 @@ See the `/docs` folder for detailed documentation:
 ## 📄 License
 
 MIT License - see LICENSE file for details.
-

--- a/cmd/praxis-explorer/main.go
+++ b/cmd/praxis-explorer/main.go
@@ -1,22 +1,23 @@
 package main
 
 import (
-    "log"
-    "os"
+	"log"
+	"os"
 
-    explorer "github.com/praxis/praxis-go-sdk/internal/explorer"
+	explorer "github.com/praxis/praxis-go-sdk/internal/explorer"
 )
 
 func main() {
-    srv, err := explorer.NewServerFromEnv()
-    if err != nil {
-        log.Fatalf("explorer init error: %v", err)
-    }
-    go srv.RunIndexer()
-    port := os.Getenv("EXPLORER_PORT")
-    if port == "" { port = "8080" }
-    if err := srv.RunHTTP(":" + port); err != nil {
-        log.Fatalf("explorer http error: %v", err)
-    }
+	srv, err := explorer.NewServerFromEnv()
+	if err != nil {
+		log.Fatalf("explorer init error: %v", err)
+	}
+	go srv.RunIndexer()
+	port := os.Getenv("EXPLORER_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	if err := srv.RunHTTP(":" + port); err != nil {
+		log.Fatalf("explorer http error: %v", err)
+	}
 }
-

--- a/internal/a2a/spec_card.go
+++ b/internal/a2a/spec_card.go
@@ -16,17 +16,17 @@ type AgentInterface struct {
 }
 
 type AgentProvider struct {
-    Organization string `json:"organization,omitempty"`
-    URL          string `json:"url,omitempty"`
+	Organization string `json:"organization,omitempty"`
+	URL          string `json:"url,omitempty"`
 }
 
 // === ERC-8004 extensions ===
 // Registration record proving on-chain identity binding for the agent.
 // agentAddress must be encoded as CAIP-10, e.g. "eip155:11155111:0xABC...".
 type ERC8004Registration struct {
-    AgentID      uint64 `json:"agentId"`
-    AgentAddress string `json:"agentAddress"`
-    Signature    string `json:"signature"` // EIP-191/EIP-712 proof of address ownership
+	AgentID      uint64 `json:"agentId"`
+	AgentAddress string `json:"agentAddress"`
+	Signature    string `json:"signature"` // EIP-191/EIP-712 proof of address ownership
 }
 
 type AgentExtension struct {
@@ -60,26 +60,26 @@ type AgentCardSignature struct {
 
 // Каноническая A2A Agent Card (см. §5.5, протокол по умолчанию "0.2.9")
 type AgentCard struct {
-    ProtocolVersion                   string                  `json:"protocolVersion"`
-    Name                              string                  `json:"name"`
-    Description                       string                  `json:"description"`
-    URL                               string                  `json:"url,omitempty"`
-    PreferredTransport                TransportProtocol       `json:"preferredTransport,omitempty"`
-    AdditionalInterfaces              []AgentInterface        `json:"additionalInterfaces,omitempty"`
-    IconURL                           string                  `json:"iconUrl,omitempty"`
-    Provider                          *AgentProvider          `json:"provider,omitempty"`
-    Version                           string                  `json:"version,omitempty"`
-    DocumentationURL                  string                  `json:"documentationUrl,omitempty"`
-    Capabilities                      AgentCapabilities       `json:"capabilities"`
-    SecuritySchemes                   map[string]any          `json:"securitySchemes,omitempty"`
-    Security                          []map[string][]string   `json:"security,omitempty"`
-    DefaultInputModes                 []string                `json:"defaultInputModes"`
-    DefaultOutputModes                []string                `json:"defaultOutputModes"`
-    Skills                            []AgentSkill            `json:"skills"`
-    SupportsAuthenticatedExtendedCard bool                    `json:"supportsAuthenticatedExtendedCard,omitempty"`
-    Signatures                        []AgentCardSignature    `json:"signatures,omitempty"`
+	ProtocolVersion                   string                `json:"protocolVersion"`
+	Name                              string                `json:"name"`
+	Description                       string                `json:"description"`
+	URL                               string                `json:"url,omitempty"`
+	PreferredTransport                TransportProtocol     `json:"preferredTransport,omitempty"`
+	AdditionalInterfaces              []AgentInterface      `json:"additionalInterfaces,omitempty"`
+	IconURL                           string                `json:"iconUrl,omitempty"`
+	Provider                          *AgentProvider        `json:"provider,omitempty"`
+	Version                           string                `json:"version,omitempty"`
+	DocumentationURL                  string                `json:"documentationUrl,omitempty"`
+	Capabilities                      AgentCapabilities     `json:"capabilities"`
+	SecuritySchemes                   map[string]any        `json:"securitySchemes,omitempty"`
+	Security                          []map[string][]string `json:"security,omitempty"`
+	DefaultInputModes                 []string              `json:"defaultInputModes"`
+	DefaultOutputModes                []string              `json:"defaultOutputModes"`
+	Skills                            []AgentSkill          `json:"skills"`
+	SupportsAuthenticatedExtendedCard bool                  `json:"supportsAuthenticatedExtendedCard,omitempty"`
+	Signatures                        []AgentCardSignature  `json:"signatures,omitempty"`
 
-    // ERC-8004 specific data at top-level per reference card
-    Registrations []ERC8004Registration `json:"registrations,omitempty"`
-    TrustModels   []string              `json:"trustModels,omitempty"`
+	// ERC-8004 specific data at top-level per reference card
+	Registrations []ERC8004Registration `json:"registrations,omitempty"`
+	TrustModels   []string              `json:"trustModels,omitempty"`
 }

--- a/internal/erc8004/identity.go
+++ b/internal/erc8004/identity.go
@@ -1,26 +1,26 @@
 package erc8004
 
 import (
-    "context"
-    "math/big"
-    "strings"
+	"context"
+	"math/big"
+	"strings"
 
-    "github.com/ethereum/go-ethereum/accounts/abi"
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type AgentInfo struct {
-    AgentId      *big.Int
-    AgentDomain  string
-    AgentAddress common.Address
+	AgentId      *big.Int
+	AgentDomain  string
+	AgentAddress common.Address
 }
 
 // internal tuple type used for ABI decoding of AgentInfo
 type agentInfoTuple struct {
-    AgentId      *big.Int
-    AgentDomain  string
-    AgentAddress common.Address
+	AgentId      *big.Int
+	AgentDomain  string
+	AgentAddress common.Address
 }
 
 // ABI for IdentityRegistry with events (from reference implementation)
@@ -37,62 +37,82 @@ const identityABI = `[
 ]`
 
 type Identity struct {
-    addr     common.Address
-    backend  bind.ContractBackend
-    contract *bind.BoundContract
-    abi      abi.ABI
+	addr     common.Address
+	backend  bind.ContractBackend
+	contract *bind.BoundContract
+	abi      abi.ABI
 }
 
 func NewIdentity(addr common.Address, backend bind.ContractBackend) (*Identity, error) {
-    parsed, err := abi.JSON(strings.NewReader(identityABI))
-    if err != nil { return nil, err }
-    c := bind.NewBoundContract(addr, parsed, backend, backend, backend)
-    return &Identity{addr: addr, backend: backend, contract: c, abi: parsed}, nil
+	parsed, err := abi.JSON(strings.NewReader(identityABI))
+	if err != nil {
+		return nil, err
+	}
+	c := bind.NewBoundContract(addr, parsed, backend, backend, backend)
+	return &Identity{addr: addr, backend: backend, contract: c, abi: parsed}, nil
 }
 
 // IdentityABI returns the ABI JSON used by this package (helper for indexer)
 func IdentityABI() string { return identityABI }
 
 func (i *Identity) NewAgent(auth *bind.TransactOpts, domain string, addr common.Address) (*big.Int, error) {
-    _, err := i.contract.Transact(auth, "newAgent", domain, addr)
-    if err != nil { return nil, err }
-    // agentId is emitted in receipt; for brevity return nil here; use receipt decode in production
-    return nil, nil
+	_, err := i.contract.Transact(auth, "newAgent", domain, addr)
+	if err != nil {
+		return nil, err
+	}
+	// agentId is emitted in receipt; for brevity return nil here; use receipt decode in production
+	return nil, nil
 }
 
 func (i *Identity) UpdateAgent(auth *bind.TransactOpts, id *big.Int, domain string, addr common.Address) (bool, error) {
-    _, err := i.contract.Transact(auth, "updateAgent", id, domain, addr)
-    return err == nil, err
+	_, err := i.contract.Transact(auth, "updateAgent", id, domain, addr)
+	return err == nil, err
 }
 
 func (i *Identity) ResolveByDomain(ctx context.Context, call *bind.CallOpts, domain string) (AgentInfo, error) {
-    if call == nil { call = &bind.CallOpts{} }
-    var res agentInfoTuple
-    out := []interface{}{&res}
-    if err := i.contract.Call(call, &out, "resolveByDomain", domain); err != nil { return AgentInfo{}, err }
-    return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
+	if call == nil {
+		call = &bind.CallOpts{}
+	}
+	var res agentInfoTuple
+	out := []interface{}{&res}
+	if err := i.contract.Call(call, &out, "resolveByDomain", domain); err != nil {
+		return AgentInfo{}, err
+	}
+	return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
 }
 
 func (i *Identity) ResolveByAddress(ctx context.Context, call *bind.CallOpts, addr common.Address) (AgentInfo, error) {
-    if call == nil { call = &bind.CallOpts{} }
-    var res agentInfoTuple
-    out := []interface{}{&res}
-    if err := i.contract.Call(call, &out, "resolveByAddress", addr); err != nil { return AgentInfo{}, err }
-    return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
+	if call == nil {
+		call = &bind.CallOpts{}
+	}
+	var res agentInfoTuple
+	out := []interface{}{&res}
+	if err := i.contract.Call(call, &out, "resolveByAddress", addr); err != nil {
+		return AgentInfo{}, err
+	}
+	return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
 }
 
 func (i *Identity) GetAgent(ctx context.Context, call *bind.CallOpts, id *big.Int) (AgentInfo, error) {
-    if call == nil { call = &bind.CallOpts{} }
-    var res agentInfoTuple
-    out := []interface{}{&res}
-    if err := i.contract.Call(call, &out, "getAgent", id); err != nil { return AgentInfo{}, err }
-    return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
+	if call == nil {
+		call = &bind.CallOpts{}
+	}
+	var res agentInfoTuple
+	out := []interface{}{&res}
+	if err := i.contract.Call(call, &out, "getAgent", id); err != nil {
+		return AgentInfo{}, err
+	}
+	return AgentInfo{AgentId: res.AgentId, AgentDomain: res.AgentDomain, AgentAddress: res.AgentAddress}, nil
 }
 
 func (i *Identity) GetAgentCount(ctx context.Context, call *bind.CallOpts) (*big.Int, error) {
-    if call == nil { call = &bind.CallOpts{} }
-    var cnt *big.Int
-    out := []interface{}{&cnt}
-    if err := i.contract.Call(call, &out, "getAgentCount"); err != nil { return nil, err }
-    return cnt, nil
+	if call == nil {
+		call = &bind.CallOpts{}
+	}
+	var cnt *big.Int
+	out := []interface{}{&cnt}
+	if err := i.contract.Call(call, &out, "getAgentCount"); err != nil {
+		return nil, err
+	}
+	return cnt, nil
 }

--- a/internal/erc8004/reputation.go
+++ b/internal/erc8004/reputation.go
@@ -3,4 +3,3 @@ package erc8004
 // Reputation registry stub — wire the real ABI for production.
 // AcceptFeedback(clientId, serverId) → emits FeedbackAuthID.
 // Indexer can also read events, but explorer only needs basic counters in MVP.
-

--- a/internal/erc8004/signature.go
+++ b/internal/erc8004/signature.go
@@ -1,29 +1,30 @@
 package erc8004
 
 import (
-    "crypto/ecdsa"
-    "fmt"
-    "strings"
+	"crypto/ecdsa"
+	"fmt"
+	"strings"
 
-    "github.com/ethereum/go-ethereum/accounts"
-    "github.com/ethereum/go-ethereum/common/hexutil"
-    "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // BuildRegistrationMessage constructs a human-readable message for EIP-191 signing.
 // You can swap this to an EIP-712 typed message later if needed.
 func BuildRegistrationMessage(chainID uint64, agentID uint64, agentAddress string, agentDomain string) string {
-    return fmt.Sprintf("Praxis Agent Registration\nchainId=%d\nagentId=%d\naddress=%s\ndomain=%s", chainID, agentID, strings.ToLower(agentAddress), agentDomain)
+	return fmt.Sprintf("Praxis Agent Registration\nchainId=%d\nagentId=%d\naddress=%s\ndomain=%s", chainID, agentID, strings.ToLower(agentAddress), agentDomain)
 }
 
 // SignRegistrationEIP191 signs the registration message using EIP-191 (personal_sign semantics).
 // Returns 0x-prefixed signature.
 func SignRegistrationEIP191(privKey *ecdsa.PrivateKey, chainID uint64, agentID uint64, agentAddress string, agentDomain string) (string, error) {
-    msg := BuildRegistrationMessage(chainID, agentID, agentAddress, agentDomain)
-    hash := accounts.TextHash([]byte(msg))
-    sig, err := crypto.Sign(hash, privKey)
-    if err != nil { return "", err }
-    // Adjust V to 27/28 form if needed; most consumers accept 0/1 in last byte already
-    return hexutil.Encode(sig), nil
+	msg := BuildRegistrationMessage(chainID, agentID, agentAddress, agentDomain)
+	hash := accounts.TextHash([]byte(msg))
+	sig, err := crypto.Sign(hash, privKey)
+	if err != nil {
+		return "", err
+	}
+	// Adjust V to 27/28 form if needed; most consumers accept 0/1 in last byte already
+	return hexutil.Encode(sig), nil
 }
-

--- a/internal/erc8004/validation.go
+++ b/internal/erc8004/validation.go
@@ -3,4 +3,3 @@ package erc8004
 // Validation registry stub — wire the real ABI for production.
 // validationRequest(validatorId, serverId, dataHash)
 // validationResponse(dataHash, score)
-

--- a/internal/explorer/api/handlers.go
+++ b/internal/explorer/api/handlers.go
@@ -1,80 +1,82 @@
 package api
 
 import (
-    "net/http"
-    "strconv"
-    "encoding/json"
-    "fmt"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
 
-    "github.com/gin-gonic/gin"
-    "github.com/praxis/praxis-go-sdk/internal/explorer/store"
+	"github.com/gin-gonic/gin"
+	"github.com/praxis/praxis-go-sdk/internal/explorer/store"
 )
 
 func RegisterRoutes(r *gin.Engine, st *store.Postgres) {
-    r.GET("/agents", func(c *gin.Context) {
-        params := store.SearchParams{
-            Q:          c.Query("q"),
-            Network:    c.Query("network"),
-            Capability: c.Query("capability"),
-            Skill:      c.Query("skill"),
-            Tag:        c.Query("tag"),
-            TrustModel: c.Query("trustModel"),
-            Cursor:     c.Query("cursor"),
-        }
-        limitStr := c.Query("limit")
-        if limitStr != "" {
-            if v, err := strconv.Atoi(limitStr); err == nil { params.Limit = v }
-        }
-        items, next, err := st.SearchAgents(c, params)
-        if err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-            return
-        }
-        c.JSON(http.StatusOK, gin.H{"items": items, "nextCursor": next})
-    })
+	r.GET("/agents", func(c *gin.Context) {
+		params := store.SearchParams{
+			Q:          c.Query("q"),
+			Network:    c.Query("network"),
+			Capability: c.Query("capability"),
+			Skill:      c.Query("skill"),
+			Tag:        c.Query("tag"),
+			TrustModel: c.Query("trustModel"),
+			Cursor:     c.Query("cursor"),
+		}
+		limitStr := c.Query("limit")
+		if limitStr != "" {
+			if v, err := strconv.Atoi(limitStr); err == nil {
+				params.Limit = v
+			}
+		}
+		items, next, err := st.SearchAgents(c, params)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"items": items, "nextCursor": next})
+	})
 
-    r.GET("/agents/:chainId/:agentId", func(c *gin.Context) {
-        ai, err := st.GetAgent(c, c.Param("chainId"), c.Param("agentId"))
-        if err != nil {
-            c.JSON(http.StatusNotFound, gin.H{"error":"not found"})
-            return
-        }
-        c.JSON(http.StatusOK, ai)
-    })
+	r.GET("/agents/:chainId/:agentId", func(c *gin.Context) {
+		ai, err := st.GetAgent(c, c.Param("chainId"), c.Param("agentId"))
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusOK, ai)
+	})
 
-    // Admin: refresh an agent by fetching card and upserting with provided agentId
-    r.POST("/admin/refresh", func(c *gin.Context) {
-        var req struct{
-            ChainID string `json:"chainId"`
-            Domain  string `json:"domain"`
-            AgentID int64  `json:"agentId"`
-            RegistryAddr string `json:"registryAddr"`
-        }
-        if err := c.ShouldBindJSON(&req); err != nil || req.ChainID == "" || req.Domain == "" || req.AgentID <= 0 {
-            c.JSON(http.StatusBadRequest, gin.H{"error":"chainId, domain, agentId required"})
-            return
-        }
-        url := req.Domain
-        if !(len(url) > 7 && (url[:7] == "http://" || (len(url) > 8 && url[:8] == "https://"))) {
-            url = fmt.Sprintf("http://%s/.well-known/agent-card.json", req.Domain)
-        }
-        resp, err := http.Get(url)
-        if err != nil {
-            c.JSON(http.StatusBadGateway, gin.H{"error":err.Error()})
-            return
-        }
-        defer resp.Body.Close()
-        var card map[string]any
-        if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
-            c.JSON(http.StatusBadGateway, gin.H{"error":err.Error()})
-            return
-        }
-        if err := st.UpsertAgentFromCard(c, req.ChainID, req.RegistryAddr, req.AgentID, req.Domain, card); err != nil {
-            c.JSON(http.StatusInternalServerError, gin.H{"error":err.Error()})
-            return
-        }
-        // best-effort: remove placeholder row with agent_id=0
-        _ = st.DeleteAgent(c, req.ChainID, 0)
-        c.JSON(http.StatusOK, gin.H{"status":"ok"})
-    })
+	// Admin: refresh an agent by fetching card and upserting with provided agentId
+	r.POST("/admin/refresh", func(c *gin.Context) {
+		var req struct {
+			ChainID      string `json:"chainId"`
+			Domain       string `json:"domain"`
+			AgentID      int64  `json:"agentId"`
+			RegistryAddr string `json:"registryAddr"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil || req.ChainID == "" || req.Domain == "" || req.AgentID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "chainId, domain, agentId required"})
+			return
+		}
+		url := req.Domain
+		if !(len(url) > 7 && (url[:7] == "http://" || (len(url) > 8 && url[:8] == "https://"))) {
+			url = fmt.Sprintf("http://%s/.well-known/agent-card.json", req.Domain)
+		}
+		resp, err := http.Get(url)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+			return
+		}
+		defer resp.Body.Close()
+		var card map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+			return
+		}
+		if err := st.UpsertAgentFromCard(c, req.ChainID, req.RegistryAddr, req.AgentID, req.Domain, card); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// best-effort: remove placeholder row with agent_id=0
+		_ = st.DeleteAgent(c, req.ChainID, 0)
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
 }

--- a/internal/explorer/indexer/config.go
+++ b/internal/explorer/indexer/config.go
@@ -1,36 +1,39 @@
 package indexer
 
 import (
-    "io/ioutil"
-    "os"
+	"io/ioutil"
+	"os"
 
-    "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 type yamlConfig struct {
-    Networks map[string]struct{
-        RPC string `yaml:"rpc"`
-        Identity string `yaml:"identity"`
-        Reputation string `yaml:"reputation"`
-        Validation string `yaml:"validation"`
-    } `yaml:"networks"`
+	Networks map[string]struct {
+		RPC        string `yaml:"rpc"`
+		Identity   string `yaml:"identity"`
+		Reputation string `yaml:"reputation"`
+		Validation string `yaml:"validation"`
+	} `yaml:"networks"`
 }
 
 func loadConfig(path string) ([]Chain, error) {
-    if path == "" {
-        return []Chain{}, nil
-    }
-    b, err := ioutil.ReadFile(path)
-    if err != nil { return []Chain{}, err }
-    var cfg yamlConfig
-    if err := yaml.Unmarshal(b, &cfg); err != nil { return []Chain{}, err }
-    out := make([]Chain, 0, len(cfg.Networks))
-    for name, n := range cfg.Networks {
-        out = append(out, Chain{
-            Name: name, RPC: os.ExpandEnv(n.RPC),
-            Identity: n.Identity, Reputation: n.Reputation, Validation: n.Validation,
-        })
-    }
-    return out, nil
+	if path == "" {
+		return []Chain{}, nil
+	}
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return []Chain{}, err
+	}
+	var cfg yamlConfig
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return []Chain{}, err
+	}
+	out := make([]Chain, 0, len(cfg.Networks))
+	for name, n := range cfg.Networks {
+		out = append(out, Chain{
+			Name: name, RPC: os.ExpandEnv(n.RPC),
+			Identity: n.Identity, Reputation: n.Reputation, Validation: n.Validation,
+		})
+	}
+	return out, nil
 }
-

--- a/internal/explorer/indexer/indexer.go
+++ b/internal/explorer/indexer/indexer.go
@@ -1,219 +1,261 @@
 package indexer
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "math/big"
-    "os"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
-    "github.com/ethereum/go-ethereum"
-    "github.com/ethereum/go-ethereum/accounts/abi"
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "github.com/ethereum/go-ethereum/ethclient"
-    erc "github.com/praxis/praxis-go-sdk/internal/erc8004"
-    "github.com/praxis/praxis-go-sdk/internal/explorer/store"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	erc "github.com/praxis/praxis-go-sdk/internal/erc8004"
+	"github.com/praxis/praxis-go-sdk/internal/explorer/store"
 )
 
 type Chain struct {
-    Name       string
-    RPC        string
-    Identity   string
-    Reputation string
-    Validation string
+	Name       string
+	RPC        string
+	Identity   string
+	Reputation string
+	Validation string
 }
 
 type Indexer struct {
-    store *store.Postgres
-    nets  []Chain
-    seeds []string // optional list of seed domains to crawl if logs are unavailable
-    // runtime
-    clients map[string]*ethclient.Client
-    idents  map[string]common.Address
-    idABI   abi.ABI
+	store *store.Postgres
+	nets  []Chain
+	seeds []string // optional list of seed domains to crawl if logs are unavailable
+	// runtime
+	clients map[string]*ethclient.Client
+	idents  map[string]common.Address
+	idABI   abi.ABI
 }
 
 func New(st *store.Postgres, cfgPath string) (*Indexer, error) {
-    // Load networks from YAML config if provided
-    nets, _ := loadConfig(cfgPath)
-    seeds := readSeedsFromEnv()
-    parsed, _ := abi.JSON(strings.NewReader(erc.IdentityABI()))
-    return &Indexer{store: st, nets: nets, seeds: seeds, clients: map[string]*ethclient.Client{}, idents: map[string]common.Address{}, idABI: parsed}, nil
+	// Load networks from YAML config if provided
+	nets, _ := loadConfig(cfgPath)
+	seeds := readSeedsFromEnv()
+	parsed, _ := abi.JSON(strings.NewReader(erc.IdentityABI()))
+	return &Indexer{store: st, nets: nets, seeds: seeds, clients: map[string]*ethclient.Client{}, idents: map[string]common.Address{}, idABI: parsed}, nil
 }
 
 func (ix *Indexer) Start(ctx context.Context) {
-    // MVP: crawl seeds periodically; on production parse cfgPath and subscribe to logs
-    t := time.NewTicker(30 * time.Second)
-    defer t.Stop()
-    ix.crawlSeeds(ctx)
-    ix.upgradeZeroIDs(ctx)
-    ix.startOnchainWatchers(ctx)
-    for {
-        select {
-        case <-ctx.Done():
-            return
-        case <-t.C:
-            ix.crawlSeeds(ctx)
-            ix.upgradeZeroIDs(ctx)
-        }
-    }
+	// MVP: crawl seeds periodically; on production parse cfgPath and subscribe to logs
+	t := time.NewTicker(30 * time.Second)
+	defer t.Stop()
+	ix.crawlSeeds(ctx)
+	ix.upgradeZeroIDs(ctx)
+	ix.startOnchainWatchers(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			ix.crawlSeeds(ctx)
+			ix.upgradeZeroIDs(ctx)
+		}
+	}
 }
 
 func (ix *Indexer) crawlSeeds(ctx context.Context) {
-    for _, domain := range ix.seeds {
-        url := fmt.Sprintf("http://%s/.well-known/agent-card.json", domain)
-        resp, err := http.Get(url)
-        if err != nil { continue }
-        dec := json.NewDecoder(resp.Body)
-        var card map[string]any
-        if err := dec.Decode(&card); err == nil {
-            _ = ix.store.UpsertAgentFromCard(ctx, "sepolia", "", 0, domain, card) // registry unknown in seed mode
-        }
-        resp.Body.Close()
-    }
+	for _, domain := range ix.seeds {
+		url := fmt.Sprintf("http://%s/.well-known/agent-card.json", domain)
+		resp, err := http.Get(url)
+		if err != nil {
+			continue
+		}
+		dec := json.NewDecoder(resp.Body)
+		var card map[string]any
+		if err := dec.Decode(&card); err == nil {
+			_ = ix.store.UpsertAgentFromCard(ctx, "sepolia", "", 0, domain, card) // registry unknown in seed mode
+		}
+		resp.Body.Close()
+	}
 }
 
 func readSeedsFromEnv() []string {
-    v := os.Getenv("EXPLORER_SEEDS")
-    if v == "" { return []string{} }
-    parts := strings.Split(v, ",")
-    out := make([]string, 0, len(parts))
-    for _, p := range parts {
-        p = strings.TrimSpace(p)
-        if p != "" { out = append(out, p) }
-    }
-    return out
+	v := os.Getenv("EXPLORER_SEEDS")
+	if v == "" {
+		return []string{}
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // --- On-chain watchers ---
 func (ix *Indexer) startOnchainWatchers(ctx context.Context) {
-    for _, n := range ix.nets {
-        if n.RPC == "" || n.Identity == "" { continue }
-        client, err := ethclient.Dial(os.ExpandEnv(n.RPC))
-        if err != nil { continue }
-        ix.clients[n.Name] = client
-        ix.idents[n.Name] = common.HexToAddress(n.Identity)
-        go ix.watchIdentity(ctx, n.Name, client, ix.idents[n.Name])
-        go ix.backfillAgents(ctx, n.Name, client, ix.idents[n.Name])
-    }
+	for _, n := range ix.nets {
+		if n.RPC == "" || n.Identity == "" {
+			continue
+		}
+		client, err := ethclient.Dial(os.ExpandEnv(n.RPC))
+		if err != nil {
+			continue
+		}
+		ix.clients[n.Name] = client
+		ix.idents[n.Name] = common.HexToAddress(n.Identity)
+		go ix.watchIdentity(ctx, n.Name, client, ix.idents[n.Name])
+		go ix.backfillAgents(ctx, n.Name, client, ix.idents[n.Name])
+	}
 }
 
 func (ix *Indexer) backfillAgents(ctx context.Context, chain string, client *ethclient.Client, idAddr common.Address) {
-    ident, err := erc.NewIdentity(idAddr, client)
-    if err != nil { return }
-    count, err := ident.GetAgentCount(ctx, &bind.CallOpts{Context: ctx})
-    if err != nil { return }
-    total := count.Int64()
-    for i := int64(1); i <= total; i++ {
-        ai, err := ident.GetAgent(ctx, &bind.CallOpts{Context: ctx}, big.NewInt(i))
-        if err != nil { continue }
-        domain := ai.AgentDomain
-        ix.fetchAndStoreCard(ctx, chain, idAddr.Hex(), ai.AgentId.Int64(), domain)
-    }
+	ident, err := erc.NewIdentity(idAddr, client)
+	if err != nil {
+		return
+	}
+	count, err := ident.GetAgentCount(ctx, &bind.CallOpts{Context: ctx})
+	if err != nil {
+		return
+	}
+	total := count.Int64()
+	for i := int64(1); i <= total; i++ {
+		ai, err := ident.GetAgent(ctx, &bind.CallOpts{Context: ctx}, big.NewInt(i))
+		if err != nil {
+			continue
+		}
+		domain := ai.AgentDomain
+		ix.fetchAndStoreCard(ctx, chain, idAddr.Hex(), ai.AgentId.Int64(), domain)
+	}
 }
 
 func (ix *Indexer) watchIdentity(ctx context.Context, chain string, client *ethclient.Client, idAddr common.Address) {
-    q := ethereum.FilterQuery{Addresses: []common.Address{idAddr}}
-    logs := make(chan types.Log)
-    sub, err := client.SubscribeFilterLogs(ctx, q, logs)
-    if err != nil { return }
-    for {
-        select {
-        case <-ctx.Done():
-            return
-        case err := <-sub.Err():
-            _ = err
-            time.Sleep(3 * time.Second)
-            go ix.watchIdentity(ctx, chain, client, idAddr)
-            return
-        case lg := <-logs:
-            ix.handleIdentityLog(ctx, chain, lg)
-        }
-    }
+	q := ethereum.FilterQuery{Addresses: []common.Address{idAddr}}
+	logs := make(chan types.Log)
+	sub, err := client.SubscribeFilterLogs(ctx, q, logs)
+	if err != nil {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-sub.Err():
+			_ = err
+			time.Sleep(3 * time.Second)
+			go ix.watchIdentity(ctx, chain, client, idAddr)
+			return
+		case lg := <-logs:
+			ix.handleIdentityLog(ctx, chain, lg)
+		}
+	}
 }
 
 func (ix *Indexer) handleIdentityLog(ctx context.Context, chain string, lg types.Log) {
-    // Try AgentRegistered
-    evReg := ix.idABI.Events["AgentRegistered"]
-    evUpd := ix.idABI.Events["AgentUpdated"]
-    switch lg.Topics[0] {
-    case evReg.ID:
-        // agentId is indexed
-        if len(lg.Topics) < 2 { return }
-        id := new(big.Int).SetBytes(lg.Topics[1].Bytes())
-        // non-indexed data: agentDomain (string), agentAddress (address)
-        var data struct{
-            AgentDomain string
-            AgentAddress common.Address
-        }
-        if err := ix.idABI.UnpackIntoInterface(&data, "AgentRegistered", lg.Data); err != nil { return }
-        reg := ix.idents[chain].Hex()
-        ix.fetchAndStoreCard(ctx, chain, reg, id.Int64(), data.AgentDomain)
-    case evUpd.ID:
-        if len(lg.Topics) < 2 { return }
-        id := new(big.Int).SetBytes(lg.Topics[1].Bytes())
-        var data struct{
-            AgentDomain string
-            AgentAddress common.Address
-        }
-        if err := ix.idABI.UnpackIntoInterface(&data, "AgentUpdated", lg.Data); err != nil { return }
-        reg := ix.idents[chain].Hex()
-        ix.fetchAndStoreCard(ctx, chain, reg, id.Int64(), data.AgentDomain)
-    }
+	// Try AgentRegistered
+	evReg := ix.idABI.Events["AgentRegistered"]
+	evUpd := ix.idABI.Events["AgentUpdated"]
+	switch lg.Topics[0] {
+	case evReg.ID:
+		// agentId is indexed
+		if len(lg.Topics) < 2 {
+			return
+		}
+		id := new(big.Int).SetBytes(lg.Topics[1].Bytes())
+		// non-indexed data: agentDomain (string), agentAddress (address)
+		var data struct {
+			AgentDomain  string
+			AgentAddress common.Address
+		}
+		if err := ix.idABI.UnpackIntoInterface(&data, "AgentRegistered", lg.Data); err != nil {
+			return
+		}
+		reg := ix.idents[chain].Hex()
+		ix.fetchAndStoreCard(ctx, chain, reg, id.Int64(), data.AgentDomain)
+	case evUpd.ID:
+		if len(lg.Topics) < 2 {
+			return
+		}
+		id := new(big.Int).SetBytes(lg.Topics[1].Bytes())
+		var data struct {
+			AgentDomain  string
+			AgentAddress common.Address
+		}
+		if err := ix.idABI.UnpackIntoInterface(&data, "AgentUpdated", lg.Data); err != nil {
+			return
+		}
+		reg := ix.idents[chain].Hex()
+		ix.fetchAndStoreCard(ctx, chain, reg, id.Int64(), data.AgentDomain)
+	}
 }
 
 func (ix *Indexer) fetchAndStoreCard(ctx context.Context, chain string, registryAddr string, agentID int64, domain string) {
-    d := strings.TrimSpace(domain)
-    if d == "" { return }
-    // basic heuristic: add http:// if missing scheme
-    url := d
-    if !strings.HasPrefix(d, "http://") && !strings.HasPrefix(d, "https://") {
-        url = fmt.Sprintf("http://%s/.well-known/agent-card.json", d)
-    } else if !strings.Contains(d, "/.well-known/agent-card.json") {
-        url = strings.TrimRight(d, "/") + "/.well-known/agent-card.json"
-    }
-    resp, err := http.Get(url)
-    if err != nil { return }
-    defer resp.Body.Close()
-    var card map[string]any
-    dec := json.NewDecoder(resp.Body)
-    if err := dec.Decode(&card); err != nil { return }
-    _ = ix.store.UpsertAgentFromCard(ctx, chain, registryAddr, agentID, d, card)
+	d := strings.TrimSpace(domain)
+	if d == "" {
+		return
+	}
+	// basic heuristic: add http:// if missing scheme
+	url := d
+	if !strings.HasPrefix(d, "http://") && !strings.HasPrefix(d, "https://") {
+		url = fmt.Sprintf("http://%s/.well-known/agent-card.json", d)
+	} else if !strings.Contains(d, "/.well-known/agent-card.json") {
+		url = strings.TrimRight(d, "/") + "/.well-known/agent-card.json"
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	var card map[string]any
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&card); err != nil {
+		return
+	}
+	_ = ix.store.UpsertAgentFromCard(ctx, chain, registryAddr, agentID, d, card)
 }
 
 // upgradeZeroIDs resolves agentId on-chain for domains saved with placeholder agent_id=0
 func (ix *Indexer) upgradeZeroIDs(ctx context.Context) {
-    for _, n := range ix.nets {
-        client := ix.clients[n.Name]
-        if client == nil {
-            // try dial if not present
-            c, err := ethclient.Dial(os.ExpandEnv(n.RPC))
-            if err != nil { continue }
-            ix.clients[n.Name] = c
-            client = c
-        }
-        idAddr, ok := ix.idents[n.Name]
-        if !ok || (idAddr == common.Address{}) {
-            ix.idents[n.Name] = common.HexToAddress(n.Identity)
-            idAddr = ix.idents[n.Name]
-        }
-        domains, err := ix.store.ListZeroIDAgents(ctx, n.Name, 200)
-        if err != nil { continue }
-        if len(domains) == 0 { continue }
-        ident, err := erc.NewIdentity(idAddr, client)
-        if err != nil { continue }
-        for _, d := range domains {
-            // resolve by domain
-            ai, err := ident.ResolveByDomain(ctx, &bind.CallOpts{Context: ctx}, d)
-            if err != nil || ai.AgentId == nil || ai.AgentId.Int64() == 0 { continue }
-            ix.fetchAndStoreCard(ctx, n.Name, idAddr.Hex(), ai.AgentId.Int64(), d)
-            // optional: delete placeholder row
-            _ = ix.store.DeleteAgent(ctx, n.Name, 0)
-        }
-    }
+	for _, n := range ix.nets {
+		client := ix.clients[n.Name]
+		if client == nil {
+			// try dial if not present
+			c, err := ethclient.Dial(os.ExpandEnv(n.RPC))
+			if err != nil {
+				continue
+			}
+			ix.clients[n.Name] = c
+			client = c
+		}
+		idAddr, ok := ix.idents[n.Name]
+		if !ok || (idAddr == common.Address{}) {
+			ix.idents[n.Name] = common.HexToAddress(n.Identity)
+			idAddr = ix.idents[n.Name]
+		}
+		domains, err := ix.store.ListZeroIDAgents(ctx, n.Name, 200)
+		if err != nil {
+			continue
+		}
+		if len(domains) == 0 {
+			continue
+		}
+		ident, err := erc.NewIdentity(idAddr, client)
+		if err != nil {
+			continue
+		}
+		for _, d := range domains {
+			// resolve by domain
+			ai, err := ident.ResolveByDomain(ctx, &bind.CallOpts{Context: ctx}, d)
+			if err != nil || ai.AgentId == nil || ai.AgentId.Int64() == 0 {
+				continue
+			}
+			ix.fetchAndStoreCard(ctx, n.Name, idAddr.Hex(), ai.AgentId.Int64(), d)
+			// optional: delete placeholder row
+			_ = ix.store.DeleteAgent(ctx, n.Name, 0)
+		}
+	}
 }

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -1,42 +1,46 @@
 package explorer
 
 import (
-    "context"
-    "os"
-    "time"
+	"context"
+	"os"
+	"time"
 
-    "github.com/gin-contrib/cors"
-    "github.com/gin-gonic/gin"
-    api "github.com/praxis/praxis-go-sdk/internal/explorer/api"
-    "github.com/praxis/praxis-go-sdk/internal/explorer/indexer"
-    "github.com/praxis/praxis-go-sdk/internal/explorer/store"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	api "github.com/praxis/praxis-go-sdk/internal/explorer/api"
+	"github.com/praxis/praxis-go-sdk/internal/explorer/indexer"
+	"github.com/praxis/praxis-go-sdk/internal/explorer/store"
 )
 
 type Server struct {
-    store   *store.Postgres
-    indexer *indexer.Indexer
-    http    *gin.Engine
+	store   *store.Postgres
+	indexer *indexer.Indexer
+	http    *gin.Engine
 }
 
 func NewServerFromEnv() (*Server, error) {
-    psql, err := store.NewPostgres(os.Getenv("DATABASE_URL"))
-    if err != nil { return nil, err }
-    ix, err := indexer.New(psql, os.Getenv("ERC8004_CONFIG")) // path to configs/erc8004.yaml
-    if err != nil { return nil, err }
-    r := gin.Default()
-    // CORS: allow browser UI at localhost:3000 (and any origin for simplicity in dev)
-    r.Use(cors.New(cors.Config{
-        AllowOrigins:     []string{"*"},
-        AllowMethods:     []string{"GET", "POST", "OPTIONS"},
-        AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
-        ExposeHeaders:    []string{"Content-Length"},
-        AllowCredentials: false,
-        MaxAge:           12 * time.Hour,
-    }))
-    s := &Server{store: psql, indexer: ix, http: r}
-    api.RegisterRoutes(r, s.store)
-    return s, nil
+	psql, err := store.NewPostgres(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		return nil, err
+	}
+	ix, err := indexer.New(psql, os.Getenv("ERC8004_CONFIG")) // path to configs/erc8004.yaml
+	if err != nil {
+		return nil, err
+	}
+	r := gin.Default()
+	// CORS: allow browser UI at localhost:3000 (and any origin for simplicity in dev)
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     []string{"*"},
+		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
+		ExposeHeaders:    []string{"Content-Length"},
+		AllowCredentials: false,
+		MaxAge:           12 * time.Hour,
+	}))
+	s := &Server{store: psql, indexer: ix, http: r}
+	api.RegisterRoutes(r, s.store)
+	return s, nil
 }
 
-func (s *Server) RunIndexer() { go s.indexer.Start(context.Background()) }
+func (s *Server) RunIndexer()               { go s.indexer.Start(context.Background()) }
 func (s *Server) RunHTTP(addr string) error { return s.http.Run(addr) }

--- a/internal/explorer/store/models.go
+++ b/internal/explorer/store/models.go
@@ -1,4 +1,3 @@
 package store
 
 // placeholder for future typed models and DTOs
-

--- a/internal/explorer/store/postgres.go
+++ b/internal/explorer/store/postgres.go
@@ -1,178 +1,208 @@
 package store
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
-    "github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-type Postgres struct { db *pgxpool.Pool }
+type Postgres struct{ db *pgxpool.Pool }
 
 func NewPostgres(url string) (*Postgres, error) {
-    pool, err := pgxpool.New(context.Background(), url)
-    if err != nil { return nil, err }
-    return &Postgres{db: pool}, nil
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		return nil, err
+	}
+	return &Postgres{db: pool}, nil
 }
 
 type AgentRow struct {
-    ChainID        string           `json:"chainId"`
-    AgentID        int64            `json:"agentId"`
-    RegistryAddr   string           `json:"registryAddr,omitempty"`
-    Domain         string           `json:"domain"`
-    AddressCAIP    string           `json:"addressCaip10"`
-    CardJSON       map[string]any   `json:"card"`
-    TrustModels    []string         `json:"trustModels"`
-    Skills         []map[string]any `json:"skills"`
-    Capabilities   map[string]any   `json:"capabilities"`
-    ScoreAvg       *float64         `json:"scoreAvg"`
-    ValidationsCnt int              `json:"validationsCnt"`
-    FeedbacksCnt   int              `json:"feedbacksCnt"`
-    LastSeenAt     time.Time        `json:"lastSeenAt"`
+	ChainID        string           `json:"chainId"`
+	AgentID        int64            `json:"agentId"`
+	RegistryAddr   string           `json:"registryAddr,omitempty"`
+	Domain         string           `json:"domain"`
+	AddressCAIP    string           `json:"addressCaip10"`
+	CardJSON       map[string]any   `json:"card"`
+	TrustModels    []string         `json:"trustModels"`
+	Skills         []map[string]any `json:"skills"`
+	Capabilities   map[string]any   `json:"capabilities"`
+	ScoreAvg       *float64         `json:"scoreAvg"`
+	ValidationsCnt int              `json:"validationsCnt"`
+	FeedbacksCnt   int              `json:"feedbacksCnt"`
+	LastSeenAt     time.Time        `json:"lastSeenAt"`
 }
 
 type SearchParams struct {
-    Q          string
-    Network    string
-    Capability string
-    Skill      string
-    Tag        string
-    TrustModel string
-    Limit      int
-    Cursor     string
+	Q          string
+	Network    string
+	Capability string
+	Skill      string
+	Tag        string
+	TrustModel string
+	Limit      int
+	Cursor     string
 }
 
 func (s *Postgres) UpsertAgentFromCard(ctx context.Context, chainID string, registryAddr string, agentID int64, domain string, card map[string]any) error {
-    // Extract fields for indices
-    address := ""
-    if regs, ok := card["registrations"].([]any); ok && len(regs) > 0 {
-        if first, ok := regs[0].(map[string]any); ok {
-            if v, ok := first["agentAddress"].(string); ok { address = v }
-            if v2, ok2 := first["addressCaip10"].(string); ok2 && address=="" { address = v2 } // backward compat
-        }
-    }
-    trustModels := []string{}
-    if arr, ok := card["trustModels"].([]any); ok {
-        for _, x := range arr { if s, ok := x.(string); ok { trustModels = append(trustModels, strings.ToLower(s)) } }
-    }
-    var skills []map[string]any
-    if arr, ok := card["skills"].([]any); ok {
-        for _, it := range arr { if m, ok := it.(map[string]any); ok { skills = append(skills, m) } }
-    }
-    caps := map[string]any{}
-    if m, ok := card["capabilities"].(map[string]any); ok { caps = m }
+	// Extract fields for indices
+	address := ""
+	if regs, ok := card["registrations"].([]any); ok && len(regs) > 0 {
+		if first, ok := regs[0].(map[string]any); ok {
+			if v, ok := first["agentAddress"].(string); ok {
+				address = v
+			}
+			if v2, ok2 := first["addressCaip10"].(string); ok2 && address == "" {
+				address = v2
+			} // backward compat
+		}
+	}
+	trustModels := []string{}
+	if arr, ok := card["trustModels"].([]any); ok {
+		for _, x := range arr {
+			if s, ok := x.(string); ok {
+				trustModels = append(trustModels, strings.ToLower(s))
+			}
+		}
+	}
+	var skills []map[string]any
+	if arr, ok := card["skills"].([]any); ok {
+		for _, it := range arr {
+			if m, ok := it.(map[string]any); ok {
+				skills = append(skills, m)
+			}
+		}
+	}
+	caps := map[string]any{}
+	if m, ok := card["capabilities"].(map[string]any); ok {
+		caps = m
+	}
 
-    b, _ := json.Marshal(card)
-    _, err := s.db.Exec(ctx, `
+	b, _ := json.Marshal(card)
+	_, err := s.db.Exec(ctx, `
         INSERT INTO agents (chain_id, registry_addr, agent_id, domain, address_caip10, card_json, trust_models, skills, capabilities, last_seen_at)
         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
         ON CONFLICT (chain_id, agent_id)
         DO UPDATE SET registry_addr=EXCLUDED.registry_addr, domain=EXCLUDED.domain, address_caip10=EXCLUDED.address_caip10, card_json=EXCLUDED.card_json, trust_models=EXCLUDED.trust_models, skills=EXCLUDED.skills, capabilities=EXCLUDED.capabilities, last_seen_at=now()
     `, chainID, registryAddr, agentID, domain, address, b, trustModels, skills, caps)
-    return err
+	return err
 }
 
 func (s *Postgres) SearchAgents(ctx context.Context, p SearchParams) ([]AgentRow, string, error) {
-    limit := 50
-    if p.Limit > 0 && p.Limit <= 200 { limit = p.Limit }
-    where := []string{}
-    args := []any{}
+	limit := 50
+	if p.Limit > 0 && p.Limit <= 200 {
+		limit = p.Limit
+	}
+	where := []string{}
+	args := []any{}
 
-    // q: search by domain or name or skill name
-    if q := strings.TrimSpace(p.Q); q != "" {
-        args = append(args, "%"+q+"%")
-        idx := len(args)
-        where = append(where, fmt.Sprintf("(domain ILIKE $%d OR card_json->>'name' ILIKE $%d OR EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s WHERE s->>'name' ILIKE $%d))", idx, idx, idx))
-    }
-    // trustModel: case-insensitive
-    if tm := strings.TrimSpace(p.TrustModel); tm != "" {
-        args = append(args, strings.ToLower(tm))
-        idx := len(args)
-        where = append(where, fmt.Sprintf("$%d = ANY(trust_models)", idx))
-    }
-    // skill: by id or name
-    if sk := strings.TrimSpace(p.Skill); sk != "" {
-        args = append(args, "%"+sk+"%")
-        idx := len(args)
-        where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s WHERE s->>'id' ILIKE $%d OR s->>'name' ILIKE $%d)", idx, idx))
-    }
-    // tag: inside skills[].tags
-    if tg := strings.TrimSpace(p.Tag); tg != "" {
-        args = append(args, strings.ToLower(tg))
-        idx := len(args)
-        where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s, jsonb_array_elements_text(COALESCE(s->'tags','[]'::jsonb)) t WHERE lower(t)= $%d)", idx))
-    }
-    // capability: presence in card_json.capabilities keys or true value
-    if cap := strings.TrimSpace(p.Capability); cap != "" {
-        // presence of key OR key set to true
-        args = append(args, cap)
-        idx := len(args)
-        where = append(where, fmt.Sprintf("((card_json->'capabilities' ? $%d) OR ((card_json->'capabilities'->>$%d)::boolean IS TRUE))", idx, idx))
-    }
-    // network: chain_id equals (optional)
-    if net := strings.TrimSpace(p.Network); net != "" {
-        args = append(args, net)
-        idx := len(args)
-        where = append(where, fmt.Sprintf("chain_id = $%d", idx))
-    }
+	// q: search by domain or name or skill name
+	if q := strings.TrimSpace(p.Q); q != "" {
+		args = append(args, "%"+q+"%")
+		idx := len(args)
+		where = append(where, fmt.Sprintf("(domain ILIKE $%d OR card_json->>'name' ILIKE $%d OR EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s WHERE s->>'name' ILIKE $%d))", idx, idx, idx))
+	}
+	// trustModel: case-insensitive
+	if tm := strings.TrimSpace(p.TrustModel); tm != "" {
+		args = append(args, strings.ToLower(tm))
+		idx := len(args)
+		where = append(where, fmt.Sprintf("$%d = ANY(trust_models)", idx))
+	}
+	// skill: by id or name
+	if sk := strings.TrimSpace(p.Skill); sk != "" {
+		args = append(args, "%"+sk+"%")
+		idx := len(args)
+		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s WHERE s->>'id' ILIKE $%d OR s->>'name' ILIKE $%d)", idx, idx))
+	}
+	// tag: inside skills[].tags
+	if tg := strings.TrimSpace(p.Tag); tg != "" {
+		args = append(args, strings.ToLower(tg))
+		idx := len(args)
+		where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements(skills) s, jsonb_array_elements_text(COALESCE(s->'tags','[]'::jsonb)) t WHERE lower(t)= $%d)", idx))
+	}
+	// capability: presence in card_json.capabilities keys or true value
+	if cap := strings.TrimSpace(p.Capability); cap != "" {
+		// presence of key OR key set to true
+		args = append(args, cap)
+		idx := len(args)
+		where = append(where, fmt.Sprintf("((card_json->'capabilities' ? $%d) OR ((card_json->'capabilities'->>$%d)::boolean IS TRUE))", idx, idx))
+	}
+	// network: chain_id equals (optional)
+	if net := strings.TrimSpace(p.Network); net != "" {
+		args = append(args, net)
+		idx := len(args)
+		where = append(where, fmt.Sprintf("chain_id = $%d", idx))
+	}
 
-    sql := `
+	sql := `
         SELECT chain_id, agent_id, registry_addr, domain, address_caip10, card_json, trust_models, skills, capabilities, score_avg, validations_cnt, feedbacks_cnt, last_seen_at
         FROM agents`
-    if len(where) > 0 {
-        sql += " WHERE " + strings.Join(where, " AND ")
-    }
-    sql += " ORDER BY last_seen_at DESC LIMIT $" + fmt.Sprint(len(args)+1)
-    args = append(args, limit)
+	if len(where) > 0 {
+		sql += " WHERE " + strings.Join(where, " AND ")
+	}
+	sql += " ORDER BY last_seen_at DESC LIMIT $" + fmt.Sprint(len(args)+1)
+	args = append(args, limit)
 
-    rows, err := s.db.Query(ctx, sql, args...)
-    if err != nil { return nil, "", err }
-    defer rows.Close()
-    var out []AgentRow
-    for rows.Next() {
-        var r AgentRow
-        var cardBytes []byte
-        err := rows.Scan(&r.ChainID, &r.AgentID, &r.RegistryAddr, &r.Domain, &r.AddressCAIP, &cardBytes, &r.TrustModels, &r.Skills, &r.Capabilities, &r.ScoreAvg, &r.ValidationsCnt, &r.FeedbacksCnt, &r.LastSeenAt)
-        if err != nil { return nil, "", err }
-        _ = json.Unmarshal(cardBytes, &r.CardJSON)
-        out = append(out, r)
-    }
-    return out, "", nil
+	rows, err := s.db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+	var out []AgentRow
+	for rows.Next() {
+		var r AgentRow
+		var cardBytes []byte
+		err := rows.Scan(&r.ChainID, &r.AgentID, &r.RegistryAddr, &r.Domain, &r.AddressCAIP, &cardBytes, &r.TrustModels, &r.Skills, &r.Capabilities, &r.ScoreAvg, &r.ValidationsCnt, &r.FeedbacksCnt, &r.LastSeenAt)
+		if err != nil {
+			return nil, "", err
+		}
+		_ = json.Unmarshal(cardBytes, &r.CardJSON)
+		out = append(out, r)
+	}
+	return out, "", nil
 }
 
 func (s *Postgres) GetAgent(ctx context.Context, chainID, agentID string) (AgentRow, error) {
-    row := s.db.QueryRow(ctx, `
+	row := s.db.QueryRow(ctx, `
         SELECT chain_id, agent_id, registry_addr, domain, address_caip10, card_json, trust_models, skills, capabilities, score_avg, validations_cnt, feedbacks_cnt, last_seen_at
         FROM agents WHERE chain_id=$1 AND agent_id=$2
     `, chainID, agentID)
-    var r AgentRow
-    var cardBytes []byte
-    err := row.Scan(&r.ChainID, &r.AgentID, &r.RegistryAddr, &r.Domain, &r.AddressCAIP, &cardBytes, &r.TrustModels, &r.Skills, &r.Capabilities, &r.ScoreAvg, &r.ValidationsCnt, &r.FeedbacksCnt, &r.LastSeenAt)
-    if err != nil { return AgentRow{}, err }
-    _ = json.Unmarshal(cardBytes, &r.CardJSON)
-    return r, nil
+	var r AgentRow
+	var cardBytes []byte
+	err := row.Scan(&r.ChainID, &r.AgentID, &r.RegistryAddr, &r.Domain, &r.AddressCAIP, &cardBytes, &r.TrustModels, &r.Skills, &r.Capabilities, &r.ScoreAvg, &r.ValidationsCnt, &r.FeedbacksCnt, &r.LastSeenAt)
+	if err != nil {
+		return AgentRow{}, err
+	}
+	_ = json.Unmarshal(cardBytes, &r.CardJSON)
+	return r, nil
 }
 
 // ListZeroIDAgents returns domains that were indexed with placeholder agent_id=0 for a given chain.
 func (s *Postgres) ListZeroIDAgents(ctx context.Context, chainID string, limit int) ([]string, error) {
-    if limit <= 0 || limit > 1000 { limit = 100 }
-    rows, err := s.db.Query(ctx, `SELECT domain FROM agents WHERE chain_id=$1 AND agent_id=0 LIMIT $2`, chainID, limit)
-    if err != nil { return nil, err }
-    defer rows.Close()
-    out := []string{}
-    for rows.Next() {
-        var d string
-        if err := rows.Scan(&d); err != nil { return nil, err }
-        out = append(out, d)
-    }
-    return out, nil
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	rows, err := s.db.Query(ctx, `SELECT domain FROM agents WHERE chain_id=$1 AND agent_id=0 LIMIT $2`, chainID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var d string
+		if err := rows.Scan(&d); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
 }
 
 // DeleteAgent removes a specific (chain_id, agent_id) row.
 func (s *Postgres) DeleteAgent(ctx context.Context, chainID string, agentID int64) error {
-    _, err := s.db.Exec(ctx, `DELETE FROM agents WHERE chain_id=$1 AND agent_id=$2`, chainID, agentID)
-    return err
+	_, err := s.db.Exec(ctx, `DELETE FROM agents WHERE chain_id=$1 AND agent_id=$2`, chainID, agentID)
+	return err
 }

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -110,7 +110,7 @@ func (c *LLMClient) GenerateWorkflowFromNaturalLanguage(ctx context.Context, use
 	}
 
 	systemPrompt := c.buildSystemPrompt(networkContext)
-	
+
 	// Validate systemPrompt is not empty
 	if strings.TrimSpace(systemPrompt) == "" {
 		c.logger.Error("System prompt is empty, using fallback")
@@ -118,7 +118,7 @@ func (c *LLMClient) GenerateWorkflowFromNaturalLanguage(ctx context.Context, use
 	}
 
 	c.logger.Debugf("🤖 System prompt length: %d, User request length: %d", len(systemPrompt), len(userRequest))
-	
+
 	req := openai.ChatCompletionRequest{
 		Model:     openai.GPT4o,
 		MaxTokens: 4096,
@@ -222,12 +222,12 @@ func (c *LLMClient) buildSystemPrompt(ctx *NetworkContext) string {
 		toolsDocumentation.WriteString("Usage: agent_id=local, tool_name=fallback_tool\n\n")
 	}
 
-    return fmt.Sprintf("You are an intelligent AI ORCHESTRATOR for a distributed P2P agent network.\n\n"+
-        "YOUR ROLE:\n"+
-        "- Understand any user message as a task request (NO 'CALL' keyword needed)\n"+
-        "- Select the BEST agent and tool for each task\n"+
-        "- Route tasks to the most appropriate agent based on capabilities\n"+
-        "- Create efficient workflows using available tools\n\n"+
+	return fmt.Sprintf("You are an intelligent AI ORCHESTRATOR for a distributed P2P agent network.\n\n"+
+		"YOUR ROLE:\n"+
+		"- Understand any user message as a task request (NO 'CALL' keyword needed)\n"+
+		"- Select the BEST agent and tool for each task\n"+
+		"- Route tasks to the most appropriate agent based on capabilities\n"+
+		"- Create efficient workflows using available tools\n\n"+
 		"AGENT SELECTION CRITERIA:\n"+
 		"1. Tool availability - Does the agent have the required tool?\n"+
 		"2. Agent specialization - Some agents may be specialized for certain tasks\n"+
@@ -418,7 +418,7 @@ Tweets:
 %s
 
 Provide a 3-4 paragraph summary in a professional tone.`, len(tweetTexts), strings.Join(tweetTexts, "\n\n"))
-	
+
 	// Validate prompt is not empty
 	if strings.TrimSpace(prompt) == "" {
 		return "", fmt.Errorf("generated prompt is empty")
@@ -430,7 +430,7 @@ Provide a 3-4 paragraph summary in a professional tone.`, len(tweetTexts), strin
 	}
 
 	c.logger.Debugf("🤖 Tweet summary - System message length: %d, Prompt length: %d", len(systemMessage), len(prompt))
-	
+
 	req := openai.ChatCompletionRequest{
 		Model: openai.GPT4oMini,
 		Messages: []openai.ChatCompletionMessage{

--- a/test_a2a_full_docker.sh
+++ b/test_a2a_full_docker.sh
@@ -65,7 +65,7 @@ wait_for_service() {
     local service_name=$2
     local timeout=${3:-30}
     local count=0
-    
+
     echo "Waiting for $service_name to be ready (timeout: ${timeout}s)..."
     while [ $count -lt $timeout ]; do
         if curl -s "$url" > /dev/null 2>&1; then
@@ -76,7 +76,7 @@ wait_for_service() {
         count=$((count + 1))
         sleep 1
     done
-    
+
     print_error "$service_name failed to start within $timeout seconds"
     return 1
 }
@@ -84,7 +84,7 @@ wait_for_service() {
 # Function to check prerequisites
 check_prerequisites() {
     print_test "CHECKING PREREQUISITES"
-    
+
     # Check OpenAI API key
     if [ -z "$OPENAI_API_KEY" ]; then
         print_error "OPENAI_API_KEY environment variable not set"
@@ -93,7 +93,7 @@ check_prerequisites() {
     else
         print_success "OpenAI API key configured (${OPENAI_API_KEY:0:20}...)"
     fi
-    
+
     # Check required commands
     local required_commands=("docker" "docker-compose" "curl" "jq")
     for cmd in "${required_commands[@]}"; do
@@ -109,33 +109,33 @@ check_prerequisites() {
 # Function to clean environment
 clean_environment() {
     print_test "CLEANING ENVIRONMENT"
-    
+
     # Stop any existing containers
     print_info "Stopping existing containers..."
     docker-compose down --remove-orphans --volumes > /dev/null 2>&1 || true
-    
+
     # Kill any running processes
     print_info "Cleaning up processes..."
     pkill -f "mcp-filesystem-server" > /dev/null 2>&1 || true
     pkill -f "praxis-agent" > /dev/null 2>&1 || true
-    
+
     # Wait for ports to be free
     sleep 3
-    
+
     print_success "Environment cleaned"
 }
 
 # Function to start MCP server
 start_mcp_server() {
     print_test "STARTING MCP FILESYSTEM SERVER"
-    
+
     print_info "Starting MCP server on port 3000..."
     go run examples/mcp-filesystem-server.go ./shared ./configs > mcp_server.log 2>&1 &
     MCP_PID=$!
-    
+
     # Wait for MCP server to start
     sleep 5
-    
+
     if wait_for_service "http://localhost:3000" "MCP Server" 15; then
         print_success "MCP Filesystem Server started (PID: $MCP_PID)"
     else
@@ -149,7 +149,7 @@ start_mcp_server() {
 # Function to build and start agents
 start_agents() {
     print_test "BUILDING AND STARTING AGENT CONTAINERS"
-    
+
     print_info "Building Docker images..."
     if docker-compose build > build.log 2>&1; then
         print_success "Docker images built successfully"
@@ -159,7 +159,7 @@ start_agents() {
         cat build.log | tail -10
         return 1
     fi
-    
+
     print_info "Starting agent containers..."
     if OPENAI_API_KEY="$OPENAI_API_KEY" docker-compose up -d > startup.log 2>&1; then
         print_success "Containers started"
@@ -169,11 +169,11 @@ start_agents() {
         cat startup.log | tail -10
         return 1
     fi
-    
+
     # Wait for agents to be ready
     print_info "Waiting for agents to initialize..."
     sleep 15 # Give time for full initialization
-    
+
     if wait_for_service "$AGENT1_URL/health" "Agent 1" 30; then
         print_success "Agent 1 ready"
     else
@@ -181,7 +181,7 @@ start_agents() {
         docker logs praxis-agent-1 --tail 20
         return 1
     fi
-    
+
     if wait_for_service "$AGENT2_URL/health" "Agent 2" 30; then
         print_success "Agent 2 ready"
     else
@@ -194,18 +194,18 @@ start_agents() {
 # Function to verify A2A initialization
 verify_a2a_initialization() {
     print_test "VERIFYING A2A INITIALIZATION"
-    
+
     # Check agent logs for A2A components
     local agent1_a2a_logs=$(docker logs praxis-agent-1 2>&1 | grep -c "A2A TaskManager initialized successfully" || echo "0")
     local agent2_a2a_logs=$(docker logs praxis-agent-2 2>&1 | grep -c "A2A TaskManager initialized successfully" || echo "0")
-    
+
     if [ "$agent1_a2a_logs" -ge 1 ] && [ "$agent2_a2a_logs" -ge 1 ]; then
         print_success "A2A TaskManager initialized in both agents"
     else
         print_error "A2A TaskManager initialization failed"
         return 1
     fi
-    
+
     # Check A2A agent interface setup
     local a2a_interface_logs=$(docker logs praxis-agent-1 praxis-agent-2 2>&1 | grep -c "A2A agent interface set" || echo "0")
     if [ "$a2a_interface_logs" -ge 2 ]; then
@@ -219,32 +219,32 @@ verify_a2a_initialization() {
 # Function to verify P2P discovery with A2A cards
 verify_p2p_discovery() {
     print_test "VERIFYING P2P DISCOVERY AND CARD EXCHANGE"
-    
+
     # Wait for P2P discovery
     print_info "Waiting for P2P discovery to complete..."
     sleep 10
-    
+
     # Check P2P cards
     local p2p_response=$(curl -s "$AGENT1_URL/p2p/cards" || echo '{"cards":{}}')
     local peer_count=$(echo "$p2p_response" | jq '.cards | length // 0' 2>/dev/null || echo "0")
-    
+
     print_info "Found $peer_count P2P peers"
-    
+
     if [ "$peer_count" -gt 0 ]; then
         print_success "P2P discovery working: $peer_count peers discovered"
-        
+
         # Show peer information
         echo "Discovered peers:"
         echo "$p2p_response" | jq '.cards | to_entries[] | {peer: .key[:8], name: .value.name, tools: (.value.tools | length)}' 2>/dev/null || echo "Peer info parsing failed"
     else
         print_error "No P2P peers discovered"
-        
+
         # Check logs for discovery issues
         print_info "Checking discovery logs..."
         docker logs praxis-agent-1 2>&1 | grep -E "(Discovered|Card exchange|Connected)" | tail -5
         return 1
     fi
-    
+
     # Check card exchange logs
     local card_exchange_count=$(docker logs praxis-agent-1 praxis-agent-2 2>&1 | grep -c "Card exchange complete" || echo "0")
     if [ "$card_exchange_count" -ge 2 ]; then
@@ -258,14 +258,14 @@ verify_p2p_discovery() {
 # Function to test A2A agent card compliance
 test_agent_card_compliance() {
     print_test "A2A AGENT CARD COMPLIANCE"
-    
+
     # Get agent card
     local card_response=$(curl -s "$AGENT1_URL/agent/card" || echo '{}')
-    
+
     # Check required A2A fields
     local required_fields=("supportedTransports" "securitySchemes" "skills" "capabilities")
     local missing_fields=()
-    
+
     for field in "${required_fields[@]}"; do
         if echo "$card_response" | jq -e "has(\"$field\")" > /dev/null 2>&1; then
             print_success "Agent card has required field: $field"
@@ -273,10 +273,10 @@ test_agent_card_compliance() {
             missing_fields+=("$field")
         fi
     done
-    
+
     if [ ${#missing_fields[@]} -eq 0 ]; then
         print_success "Agent card is fully A2A compliant"
-        
+
         # Show A2A specific capabilities
         echo "A2A Capabilities:"
         echo "$card_response" | jq '{
@@ -293,7 +293,7 @@ test_agent_card_compliance() {
 # Function to test A2A message/send workflow
 test_a2a_message_send() {
     print_test "A2A MESSAGE/SEND WORKFLOW"
-    
+
     # Create A2A message
     local test_message='{
         "jsonrpc": "2.0",
@@ -313,22 +313,22 @@ test_a2a_message_send() {
             }
         }
     }'
-    
+
     print_info "Sending A2A message/send request..."
     local response=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$test_message")
-    
+
     echo "Response:"
     echo "$response" | jq . 2>/dev/null || echo "$response"
-    
+
     # Extract task ID
     local task_id=$(echo "$response" | jq -r '.result.id // empty' 2>/dev/null)
-    
+
     if [ -n "$task_id" ] && [ "$task_id" != "null" ]; then
         print_success "A2A task created successfully: $task_id"
         echo "$task_id" > /tmp/current_task_id
-        
+
         # Verify task structure
         if echo "$response" | jq -e '.result.kind == "task"' > /dev/null 2>&1; then
             print_success "Task structure follows A2A specification"
@@ -345,22 +345,22 @@ test_a2a_message_send() {
 # Function to test task status polling
 test_task_status_polling() {
     print_test "A2A TASK STATUS POLLING"
-    
+
     local task_id=$(cat /tmp/current_task_id 2>/dev/null)
     if [ -z "$task_id" ]; then
         print_error "No task ID available from previous test"
         return 1
     fi
-    
+
     print_info "Polling status for task: $task_id"
-    
+
     local max_attempts=20
     local attempt=1
     local final_state=""
-    
+
     while [ $attempt -le $max_attempts ]; do
         echo "Status check $attempt/$max_attempts..."
-        
+
         local status_request='{
             "jsonrpc": "2.0",
             "id": 2,
@@ -369,14 +369,14 @@ test_task_status_polling() {
                 "id": "'$task_id'"
             }
         }'
-        
+
         local status_response=$(curl -s -X POST "$AGENT1_URL/execute" \
             -H "Content-Type: application/json" \
             -d "$status_request")
-        
+
         local state=$(echo "$status_response" | jq -r '.result.status.state // .error.message // "unknown"' 2>/dev/null)
         echo "Current state: $state"
-        
+
         case "$state" in
             "submitted")
                 print_info "✳️  Task submitted, waiting for processing..."
@@ -387,7 +387,7 @@ test_task_status_polling() {
             "completed")
                 print_success "🎉 Task completed successfully!"
                 final_state="completed"
-                
+
                 # Show artifacts
                 echo "Artifacts:"
                 echo "$status_response" | jq '.result.artifacts // []' 2>/dev/null || echo "No artifacts or parsing failed"
@@ -408,11 +408,11 @@ test_task_status_polling() {
                 break
                 ;;
         esac
-        
+
         attempt=$((attempt + 1))
         sleep 2
     done
-    
+
     if [ "$final_state" = "completed" ]; then
         print_success "Task lifecycle completed successfully"
         return 0
@@ -425,25 +425,25 @@ test_task_status_polling() {
 # Function to test legacy DSL compatibility
 test_legacy_dsl_compatibility() {
     print_test "LEGACY DSL TO A2A CONVERSION"
-    
+
     local legacy_request='{
         "dsl": "get list of available tools from both agents"
     }'
-    
+
     print_info "Sending legacy DSL request..."
     echo "$legacy_request" | jq .
-    
+
     local response=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$legacy_request")
-    
+
     echo "Response:"
     echo "$response" | jq . 2>/dev/null || echo "$response"
-    
+
     # Check if converted to A2A task
     if echo "$response" | jq -e '.result.kind == "task"' > /dev/null 2>&1; then
         print_success "Legacy DSL successfully converted to A2A task"
-        
+
         local converted_task_id=$(echo "$response" | jq -r '.result.id // empty')
         if [ -n "$converted_task_id" ]; then
             print_success "Converted task ID: $converted_task_id"
@@ -457,7 +457,7 @@ test_legacy_dsl_compatibility() {
 # Function to test direct A2A endpoints
 test_direct_a2a_endpoints() {
     print_test "DIRECT A2A ENDPOINTS"
-    
+
     # Test /a2a/message/send
     print_info "Testing direct /a2a/message/send endpoint..."
     local direct_message_params='{
@@ -468,26 +468,26 @@ test_direct_a2a_endpoints() {
             "kind": "message"
         }
     }'
-    
+
     local direct_response=$(curl -s -X POST "$AGENT1_URL/a2a/message/send" \
         -H "Content-Type: application/json" \
         -d "$direct_message_params")
-    
+
     if echo "$direct_response" | jq -e '.result.id' > /dev/null 2>&1; then
         print_success "Direct A2A message/send endpoint working"
     else
         print_error "Direct A2A message/send endpoint failed"
         echo "$direct_response"
     fi
-    
+
     # Test /a2a/tasks list
     print_info "Testing /a2a/tasks list endpoint..."
     local tasks_list=$(curl -s "$AGENT1_URL/a2a/tasks")
-    
+
     if echo "$tasks_list" | jq -e '.tasks' > /dev/null 2>&1; then
         local task_count=$(echo "$tasks_list" | jq '.tasks | length // 0')
         print_success "A2A tasks list endpoint working ($task_count tasks found)"
-        
+
         # Show task statistics
         echo "Task Statistics:"
         echo "$tasks_list" | jq '.counts' 2>/dev/null || echo "Stats parsing failed"
@@ -500,10 +500,10 @@ test_direct_a2a_endpoints() {
 # Function to test inter-agent communication
 test_inter_agent_communication() {
     print_test "INTER-AGENT A2A COMMUNICATION"
-    
+
     # Test message from Agent 1 to Agent 2 via A2A
     print_info "Testing A2A communication from Agent 1 to Agent 2..."
-    
+
     local inter_agent_message='{
         "jsonrpc": "2.0",
         "id": 3,
@@ -517,25 +517,25 @@ test_inter_agent_communication() {
             }
         }
     }'
-    
+
     local inter_response=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$inter_agent_message")
-    
+
     echo "Inter-agent response:"
     echo "$inter_response" | jq . 2>/dev/null || echo "$inter_response"
-    
+
     if echo "$inter_response" | jq -e '.result.id' > /dev/null 2>&1; then
         print_success "Inter-agent A2A communication working"
-        
+
         # Monitor this task briefly
         local inter_task_id=$(echo "$inter_response" | jq -r '.result.id')
         sleep 5
-        
+
         local final_status=$(curl -s -X POST "$AGENT1_URL/execute" \
             -H "Content-Type: application/json" \
             -d '{"jsonrpc":"2.0","id":4,"method":"tasks/get","params":{"id":"'$inter_task_id'"}}')
-        
+
         local final_state=$(echo "$final_status" | jq -r '.result.status.state // "unknown"')
         print_info "Inter-agent task final state: $final_state"
     else
@@ -547,7 +547,7 @@ test_inter_agent_communication() {
 # Function to test error handling
 test_error_handling() {
     print_test "A2A ERROR HANDLING"
-    
+
     # Test invalid method
     print_info "Testing invalid JSON-RPC method..."
     local invalid_method='{
@@ -556,11 +556,11 @@ test_error_handling() {
         "method": "invalid/method",
         "params": {}
     }'
-    
+
     local error_response=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$invalid_method")
-    
+
     local error_code=$(echo "$error_response" | jq '.error.code // 0' 2>/dev/null || echo "0")
     if [ "$error_code" = "-32601" ]; then
         print_success "Method not found error handled correctly (code: $error_code)"
@@ -569,7 +569,7 @@ test_error_handling() {
         echo "$error_response"
         return 1
     fi
-    
+
     # Test non-existent task
     print_info "Testing non-existent task lookup..."
     local missing_task='{
@@ -578,11 +578,11 @@ test_error_handling() {
         "method": "tasks/get",
         "params": {"id": "non-existent-task-id"}
     }'
-    
+
     local task_error=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$missing_task")
-    
+
     local task_error_code=$(echo "$task_error" | jq '.error.code // 0' 2>/dev/null || echo "0")
     if [ "$task_error_code" = "-32001" ]; then
         print_success "Task not found error handled correctly (code: $task_error_code)"
@@ -596,23 +596,23 @@ test_error_handling() {
 # Function to analyze container logs
 analyze_container_logs() {
     print_test "ANALYZING CONTAINER LOGS FOR A2A PIPELINE"
-    
+
     print_info "Agent 1 A2A Pipeline Logs:"
     docker logs praxis-agent-1 2>&1 | grep -E "(TaskID|A2A|submitted|working|completed|message/send|tasks/get)" | tail -15 || echo "No A2A logs found"
-    
-    print_info "Agent 2 A2A Pipeline Logs:"  
+
+    print_info "Agent 2 A2A Pipeline Logs:"
     docker logs praxis-agent-2 2>&1 | grep -E "(TaskID|A2A|submitted|working|completed|message/send|tasks/get)" | tail -15 || echo "No A2A logs found"
-    
+
     # Count key log patterns
     local task_created_count=$(docker logs praxis-agent-1 praxis-agent-2 2>&1 | grep -c "Task created in 'submitted' state" || echo "0")
     local task_completed_count=$(docker logs praxis-agent-1 praxis-agent-2 2>&1 | grep -c "Status updated.*to 'completed'" || echo "0")
     local a2a_requests_count=$(docker logs praxis-agent-1 praxis-agent-2 2>&1 | grep -c "A2A Request received" || echo "0")
-    
+
     print_info "Log Analysis:"
     echo "  - Tasks created: $task_created_count"
     echo "  - Tasks completed: $task_completed_count"
     echo "  - A2A requests processed: $a2a_requests_count"
-    
+
     if [ "$task_created_count" -gt 0 ] && [ "$a2a_requests_count" -gt 0 ]; then
         print_success "A2A pipeline logs show proper task lifecycle"
     else
@@ -624,39 +624,39 @@ analyze_container_logs() {
 # Function to test performance
 test_performance() {
     print_test "A2A PERFORMANCE MEASUREMENT"
-    
+
     # Quick performance test
     local start_time=$(date +%s%N)
-    
+
     local perf_message='{
         "jsonrpc": "2.0",
         "id": 100,
         "method": "message/send",
         "params": {
             "message": {
-                "role": "user", 
+                "role": "user",
                 "parts": [{"kind": "text", "text": "performance test"}],
                 "messageId": "perf-test-001",
                 "kind": "message"
             }
         }
     }'
-    
+
     local perf_response=$(curl -s -X POST "$AGENT1_URL/execute" \
         -H "Content-Type: application/json" \
         -d "$perf_message")
-    
+
     local end_time=$(date +%s%N)
     local duration=$(( (end_time - start_time) / 1000000 )) # Convert to milliseconds
-    
+
     echo "A2A message/send response time: ${duration}ms"
-    
+
     if [ "$duration" -lt 500 ]; then
         print_success "Performance test passed: ${duration}ms < 500ms"
     else
         print_error "Performance test failed: ${duration}ms >= 500ms"
     fi
-    
+
     # Check if task was created
     if echo "$perf_response" | jq -e '.result.id' > /dev/null 2>&1; then
         print_success "Performance test task created successfully"
@@ -669,25 +669,25 @@ test_performance() {
 # Function to cleanup
 cleanup() {
     print_test "CLEANUP"
-    
+
     # Save final logs
     print_info "Saving final container logs..."
     docker logs praxis-agent-1 > agent1_final.log 2>&1 || true
     docker logs praxis-agent-2 > agent2_final.log 2>&1 || true
-    
+
     # Kill MCP server
     if [ ! -z "$MCP_PID" ]; then
         kill $MCP_PID 2>/dev/null || true
     fi
     pkill -f "mcp-filesystem-server" 2>/dev/null || true
-    
+
     # Stop containers
     print_info "Stopping containers..."
     docker-compose down --remove-orphans > /dev/null 2>&1 || true
-    
+
     # Clean up temp files
     rm -f /tmp/current_task_id mcp_server.log build.log startup.log
-    
+
     print_success "Cleanup completed"
 }
 
@@ -696,18 +696,18 @@ generate_final_report() {
     echo -e "\n${PURPLE}================================================================${NC}"
     echo -e "${PURPLE}📊 FINAL A2A TESTING REPORT${NC}"
     echo -e "${PURPLE}================================================================${NC}"
-    
+
     echo -e "\n${YELLOW}Test Summary:${NC}"
     echo "  Total Tests: $TOTAL_TESTS"
     echo "  Passed: ${GREEN}$PASSED_TESTS${NC}"
     echo "  Failed: ${RED}$FAILED_TESTS${NC}"
     echo "  Success Rate: $(( PASSED_TESTS * 100 / TOTAL_TESTS ))%"
-    
+
     echo -e "\n${YELLOW}Test Results:${NC}"
     for result in "${TEST_RESULTS[@]}"; do
         echo "  $result"
     done
-    
+
     if [ $FAILED_TESTS -eq 0 ]; then
         echo -e "\n${GREEN}🎉 ALL A2A TESTS PASSED! IMPLEMENTATION FULLY FUNCTIONAL!${NC}"
         echo -e "${GREEN}✨ The A2A protocol is working correctly with docker-compose${NC}"


### PR DESCRIPTION
## Description  
This PR fixes issues with handling external MCP addresses in the agent.  
Previously, `addr` (of type `ExternalMCPConfig`) was incorrectly passed where a string was expected.  
The changes ensure that the correct string field (e.g., `addr.URL`) is used when:  
- Registering the endpoint in `TransportManager`  
- Discovering tools via the discovery service  
- Registering fallback tools  

## Type of change  
- [x] Bug fix (non-breaking change which fixes an issue)  

## How Has This Been Tested?  
- [x] Unit tests (fixed compilation errors and validated passing tests locally)  
- [x] Manual tests (verified agent initializes correctly with external MCP configs)  

## Checklist:  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published  

## Screenshots (if appropriate):  
![telegram-cloud-photo-size-2-5375453314327642433-y](https://github.com/user-attachments/assets/58099bec-effd-4724-9e2b-94998328ad8b)

![telegram-cloud-photo-size-2-5375453314327642435-y](https://github.com/user-attachments/assets/20597533-1990-44ca-b747-27115348a07e)


## Additional context  
This fix unblocks CI by resolving type mismatches related to external MCP configuration handling.  
